### PR TITLE
feat: 실시간 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 //    testImplementation 'com.h2database:h2'
 
+    // webSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/petback/chat/config/WebSockConfig.java
+++ b/src/main/java/com/example/petback/chat/config/WebSockConfig.java
@@ -1,0 +1,21 @@
+package com.example.petback.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocket
+public class WebSockConfig implements WebSocketConfigurer {
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "ws/chat").setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/example/petback/chat/config/WebSocketHandler.java
+++ b/src/main/java/com/example/petback/chat/config/WebSocketHandler.java
@@ -1,0 +1,46 @@
+package com.example.petback.chat.config;
+
+import com.example.petback.chat.dto.MessageDto;
+import com.example.petback.chat.dto.RoomDto;
+import com.example.petback.chat.entity.ChatRoom;
+import com.example.petback.chat.repository.ChatMessageRepository;
+import com.example.petback.chat.repository.ChatRoomRepository;
+import com.example.petback.chat.service.ChatService;
+import com.example.petback.user.entity.User;
+import com.example.petback.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Slf4j(topic = "WebSocketHandler")
+@RequiredArgsConstructor
+@Component
+public class WebSocketHandler extends TextWebSocketHandler {
+    private final ObjectMapper objectMapper;
+    private final ChatService chatService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    // request 보내면 실행
+    @Override
+    @Transactional
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        // log.info("{}", payload);
+
+        MessageDto messageDto = objectMapper.readValue(payload, MessageDto.class);
+
+        User user = userRepository.findByUsername(messageDto.getSender()).get();
+        ChatRoom chatRoom = chatRoomRepository.findByUuid(messageDto.getRoomId()).get();
+        chatMessageRepository.save(messageDto.toEntity(user, chatRoom));
+
+        RoomDto roomDto = chatService.selectRoomById(messageDto.getRoomId());
+        roomDto.handlerActions(session, messageDto, chatService);
+    }
+}

--- a/src/main/java/com/example/petback/chat/controller/ChatController.java
+++ b/src/main/java/com/example/petback/chat/controller/ChatController.java
@@ -1,0 +1,35 @@
+package com.example.petback.chat.controller;
+
+import com.example.petback.chat.dto.ChatRoomResponseDto;
+import com.example.petback.chat.dto.RoomDto;
+import com.example.petback.chat.dto.RoomRequestDto;
+import com.example.petback.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatService chatService;
+
+    // 채팅방 생성
+    @PostMapping("/chats")
+    public RoomDto createRoom(@RequestBody RoomRequestDto requestDto) {
+        return chatService.createRoom(requestDto.getName());
+    }
+
+    // 채팅방 단일 조회
+    @GetMapping("/chat")
+    public ChatRoomResponseDto selectRoom(@RequestParam String uuid) {
+        return chatService.selectRoom(uuid);
+    }
+
+    // 생성된 채팅방 전체조회
+    @GetMapping("/chats")
+    public List<ChatRoomResponseDto> selectRooms() {
+        return chatService.selectRooms();
+    }
+}

--- a/src/main/java/com/example/petback/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/example/petback/chat/dto/ChatMessageResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.petback.chat.dto;
+
+import com.example.petback.chat.entity.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatMessageResponseDto {
+    private Long messageId;
+    private String message;
+    private LocalDateTime time;
+
+    public static ChatMessageResponseDto of (ChatMessage chatMessage) {
+        return ChatMessageResponseDto.builder()
+                .messageId(chatMessage.getId())
+                .message(chatMessage.getMessage())
+                .time(chatMessage.getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petback/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/petback/chat/dto/ChatRoomResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.petback.chat.dto;
+
+import com.example.petback.chat.entity.ChatMessage;
+import com.example.petback.chat.entity.ChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatRoomResponseDto {
+    private String uuid;
+    private String roomName;
+    private List<ChatMessageResponseDto> chatMessages;
+
+    public static ChatRoomResponseDto of(ChatRoom chatRoom) {
+        return ChatRoomResponseDto.builder()
+                .uuid(chatRoom.getUuid())
+                .roomName(chatRoom.getRoomName())
+                .chatMessages(chatRoom.getChatMessages().stream().map(ChatMessageResponseDto::of).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petback/chat/dto/MessageDto.java
+++ b/src/main/java/com/example/petback/chat/dto/MessageDto.java
@@ -1,0 +1,38 @@
+package com.example.petback.chat.dto;
+
+import com.example.petback.chat.entity.ChatMessage;
+import com.example.petback.chat.entity.ChatRoom;
+import com.example.petback.chat.repository.ChatRoomRepository;
+import com.example.petback.user.entity.User;
+import com.example.petback.user.repository.UserRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class MessageDto {
+
+    public enum MessageType {
+        ENTER, TALK // 입장, 메시지전달
+    }
+
+    private MessageType type;
+    private String roomId;
+    private String sender;
+    private String message;
+    private LocalDateTime time = LocalDateTime.now();
+
+    public ChatMessage toEntity(User user, ChatRoom chatRoom) {
+        return ChatMessage.builder()
+                .message(message)
+                .time(time)
+                .user(user)
+                .chatRoom(chatRoom)
+                .build();
+    }
+}

--- a/src/main/java/com/example/petback/chat/dto/RoomDto.java
+++ b/src/main/java/com/example/petback/chat/dto/RoomDto.java
@@ -1,0 +1,45 @@
+package com.example.petback.chat.dto;
+
+import com.example.petback.chat.entity.ChatRoom;
+import com.example.petback.chat.service.ChatService;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+public class RoomDto {
+    private String roomId;
+    private String name;
+    private Set<WebSocketSession> sessions = new HashSet<>();
+
+    @Builder
+    public RoomDto(String roomId, String name) {
+        this.roomId = roomId;
+        this.name = name;
+    }
+
+    public void handlerActions(WebSocketSession session, MessageDto messageDto, ChatService chatService) {
+        if (messageDto.getType().equals(MessageDto.MessageType.ENTER)) {
+            sessions.add(session);
+            messageDto.setMessage(messageDto.getSender() + "님이 입장했습니다.");
+        }
+        sendMessage(messageDto, chatService);
+
+    }
+
+    private <T> void sendMessage(T message, ChatService chatService) {
+        sessions.parallelStream()
+                .forEach(session -> chatService.sendMessage(session, message));
+    }
+
+    public ChatRoom toEntity(String uuid, String roomName) {
+        return ChatRoom.builder()
+                .uuid(uuid)
+                .roomName(roomName)
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/petback/chat/dto/RoomRequestDto.java
+++ b/src/main/java/com/example/petback/chat/dto/RoomRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.petback.chat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoomRequestDto {
+    private String name;
+}

--- a/src/main/java/com/example/petback/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/petback/chat/entity/ChatMessage.java
@@ -1,0 +1,33 @@
+package com.example.petback.chat.entity;
+
+import com.example.petback.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "ChatMessages")
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String message;
+
+    @Column
+    private LocalDateTime time;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private ChatRoom chatRoom;
+}

--- a/src/main/java/com/example/petback/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/petback/chat/entity/ChatRoom.java
@@ -1,0 +1,27 @@
+package com.example.petback.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "ChatRooms")
+public class ChatRoom {
+    @Id
+    private String uuid;
+
+    @Column
+    private String roomName;
+
+    @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
+    private List<ChatMessage> ChatMessages = new ArrayList<>();
+}

--- a/src/main/java/com/example/petback/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/petback/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.example.petback.chat.repository;
+
+import com.example.petback.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/example/petback/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/petback/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,13 @@
+package com.example.petback.chat.repository;
+
+import com.example.petback.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
+    Optional<ChatRoom> findByUuid(String uuid);
+
+}

--- a/src/main/java/com/example/petback/chat/service/ChatService.java
+++ b/src/main/java/com/example/petback/chat/service/ChatService.java
@@ -1,0 +1,74 @@
+package com.example.petback.chat.service;
+
+import com.example.petback.chat.dto.ChatRoomResponseDto;
+import com.example.petback.chat.dto.RoomDto;
+import com.example.petback.chat.entity.ChatRoom;
+import com.example.petback.chat.repository.ChatRoomRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatService {
+    private final ObjectMapper objectMapper;
+    private final ChatRoomRepository chatRoomRepository;
+    private Map<String, RoomDto> chatRooms;
+
+    @PostConstruct // 빈 생성과 의존성 주입이 완료된 후 호출되는 초기화 메소드
+    private void init() {
+        chatRooms = new LinkedHashMap<>();
+    }
+
+    public List<RoomDto> findRooms() {
+        return new ArrayList<>(chatRooms.values());
+    }
+
+    public RoomDto selectRoomById(String roomId) {
+        return chatRooms.get(roomId);
+    }
+
+    @Transactional
+    public RoomDto createRoom(String name) {
+        String randomId = UUID.randomUUID().toString();
+        RoomDto roomDto = RoomDto.builder()
+                .roomId(randomId)
+                .name(name)
+                .build();
+        chatRooms.put(randomId, roomDto);
+
+        ChatRoom chatRoom = roomDto.toEntity(randomId, name);
+        chatRoomRepository.save(chatRoom);
+        return roomDto;
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoomResponseDto selectRoom(String uuid) {
+        ChatRoom chatRoom = chatRoomRepository.findByUuid(uuid).get();
+        return ChatRoomResponseDto.of(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponseDto> selectRooms() {
+        return chatRoomRepository.findAll().stream().map(ChatRoomResponseDto::of).toList();
+    }
+
+    public <T> void sendMessage(WebSocketSession session, T message) {
+        try{
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            // throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/example/petback/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/petback/common/config/WebSecurityConfig.java
@@ -51,11 +51,6 @@ public class WebSecurityConfig {
         return filter;
     }
 
-//     @Bean
-//     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-//         return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
-//     }
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         // CSRF 설정
@@ -69,8 +64,11 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                        .requestMatchers("/api/users/**").permitAll() // '/users/'로 시작하는 요청 모두 접근 허가
-                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리 -->permitAll
+                        .requestMatchers("/api/users/**").permitAll() //
+                        .requestMatchers("/ws/**").permitAll() // ws에서 접속하는 websocket 권한 허용
+                        .requestMatchers("/chats").permitAll() // 채팅방 조회를 위한 권한 허용
+                        .requestMatchers("/chat").permitAll() // 채팅방 조회를 위한 권한 허용
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리 --> permitAll
 
         );
 

--- a/src/main/java/com/example/petback/common/jwt/JwtUtil.java
+++ b/src/main/java/com/example/petback/common/jwt/JwtUtil.java
@@ -66,7 +66,6 @@ public class JwtUtil {
     // header 에서 JWT 가져오기
     public String getJwtFromHeader(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        System.out.println(bearerToken);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
         }

--- a/src/main/java/com/example/petback/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/petback/user/dto/SignupRequestDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SignupRequestDto {
-    @NotBlank
+    @NotBlank(message = "null 과 \"\" 과 \" \" 모두 허용하지 않습니다.")
     private String username;
     @NotBlank
     private String password;
@@ -19,9 +19,6 @@ public class SignupRequestDto {
     @Email
     @NotBlank
     private String email;
-
-    @Builder.Default
-    private UserRoleEnum role= UserRoleEnum.USER;
 
     public void setPassword(String password) {
         this.password = password;
@@ -33,7 +30,6 @@ public class SignupRequestDto {
                 .password(password)
                 .email(email)
                 .nickname(nickname)
-                .role(role)
                 .build();
     }
 }

--- a/src/main/java/com/example/petback/user/entity/User.java
+++ b/src/main/java/com/example/petback/user/entity/User.java
@@ -1,9 +1,12 @@
 package com.example.petback.user.entity;
 
-import com.example.petback.hospital.entity.Hospital;
+import com.example.petback.chat.entity.ChatMessage;
 import com.example.petback.user.enums.UserRoleEnum;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -11,6 +14,7 @@ import lombok.*;
 @Getter
 @Setter
 @Builder
+@Table(name = "Users")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,8 +30,9 @@ public class User {
     private String imageUrl;
 
     @Enumerated(value = EnumType.STRING)
-    private UserRoleEnum role;
+    @Builder.Default
+    private UserRoleEnum role= UserRoleEnum.USER;
 
-    @OneToOne(mappedBy = "user")
-    private Hospital hospital;
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
 }

--- a/src/main/java/com/example/petback/user/repository/UserRepository.java
+++ b/src/main/java/com/example/petback/user/repository/UserRepository.java
@@ -2,9 +2,11 @@ package com.example.petback.user.repository;
 
 import com.example.petback.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 

--- a/src/main/java/com/example/petback/user/service/UserService.java
+++ b/src/main/java/com/example/petback/user/service/UserService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
     public void signUp(SignupRequestDto requestDto) {
         String password = passwordEncoder.encode(requestDto.getPassword());
         requestDto.setPassword(password);


### PR DESCRIPTION
## 회원가입 / 로그인 이후 채팅방을 생성합니다.
![image](https://github.com/PetCommunityWeb/PetCommunityBack/assets/78305720/72335931-a665-4d9d-a0a1-1b89ce6f3e58)

## 생성된 채팅방을 단일조회 합니다. 채팅방의 경우 키값이 uuid라 requestParam 어노테이션으로 매개변수를 받았습니다. pathvariable로 통일할지 고려해봐야 할 것 같습니다.
## websocket 세션에서 진행됬던 채팅로그를 응답으로 내려줍니다.
![image](https://github.com/PetCommunityWeb/PetCommunityBack/assets/78305720/87175ee2-3e20-4eb1-a6ee-ee97638cc81c)

## 채팅방을 전체조회합니다. db에 저장된 모든 채팅방의 정보를 반환합니다.
![image](https://github.com/PetCommunityWeb/PetCommunityBack/assets/78305720/82449203-e0ad-486c-9006-d07fc2891ddf)

## 웹 소켓 테스트 클라이언트로 테스트한 화면입니다.
### Request 형식
{
  "type":"ENTER",
  "roomId":"4b5ca5b5-1bfe-4842-a9d1-a11fe16a5b68",
  "sender":"test1",
  "message":"다른방 메시지1"
}
type은 입장 멘트를 내려주기 위해 확인하는 flag입니다. 방에 처음 입장한다면 "type":"ENTER"로 지정하여 request를 보냅니다.
![image](https://github.com/PetCommunityWeb/PetCommunityBack/assets/78305720/8a2c37cc-f046-4a83-a6a2-21d76ee923f8)



