### PR TITLE
[Refactor] refreshToken 만료시 exception 처리 및 클라이언트에 응답

### DIFF
--- a/src/main/java/com/example/petback/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/petback/common/exception/GlobalExceptionHandler.java
@@ -6,9 +6,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.NoSuchElementException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(IllegalArgumentException.class)
+    @ExceptionHandler({IllegalArgumentException.class, NoSuchElementException.class})
     public ResponseEntity illegalExceptionHandler(Exception ex) {
         return ResponseEntity.ok().body(new ApiResponseDto(ex.getMessage(), HttpStatus.BAD_REQUEST.value()));
     }

--- a/src/main/java/com/example/petback/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/petback/user/repository/RefreshTokenRepository.java
@@ -4,6 +4,5 @@ import com.example.petback.common.jwt.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-    RefreshToken findByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/com/example/petback/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/petback/user/service/UserServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -95,7 +96,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Map<String, String> refreshToken(String refreshToken) {
-        RefreshToken redisToken = refreshTokenRepository.findById(refreshToken).get(); // 무조건 @Id로만 찾기
+        RefreshToken redisToken = refreshTokenRepository.findById(refreshToken)
+            .orElseThrow(() -> new NoSuchElementException("refreshToken이 만료되었습니다.")); // 무조건 @Id로만 찾기
         Long userId = redisToken.getUserId();
         User user = userRepository.findById(userId).get();
         Map<String, String> tokens = new HashMap<>();


### PR DESCRIPTION
optional 객체를 불러오지 못할때 NoSuchElementException을 던져서 Global Exceptionhandler에서 캐치해서 응답을 내려주도록 하였습니다.
```
    @Override
    public Map<String, String> refreshToken(String refreshToken) {
        RefreshToken redisToken = refreshTokenRepository.findById(refreshToken)
            .orElseThrow(() -> new NoSuchElementException("refreshToken이 만료되었습니다.")); // 무조건 @Id로만 찾기
        Long userId = redisToken.getUserId();
        User user = userRepository.findById(userId).get();
        Map<String, String> tokens = new HashMap<>();
```