### PR TITLE
탈퇴 회원 복구 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 
     // redis 구현체로 Lettuce 사용
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
+
+    // JavaMail -> 이메일 인증
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/petback/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/petback/chat/entity/ChatMessage.java
@@ -32,4 +32,10 @@ public class ChatMessage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private ChatRoom chatRoom;
+
+    @Builder.Default
+    private boolean isDeleted = Boolean.FALSE;
+    public void setDeleted(boolean isDeleted) {
+        this.isDeleted = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/example/petback/comment/entity/Comment.java
+++ b/src/main/java/com/example/petback/comment/entity/Comment.java
@@ -42,5 +42,5 @@ public class Comment {
     }
     public void setDeleted(boolean isDeleted) {
         this.isDeleted = Boolean.TRUE;
-    }
+}
 }

--- a/src/main/java/com/example/petback/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/petback/common/config/WebSecurityConfig.java
@@ -75,6 +75,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/chat").permitAll() // 채팅방 조회를 위한 권한 허용
                         .requestMatchers("/api/feeds/**").permitAll()
                         .requestMatchers("/api/comments/**").permitAll()
+                        .requestMatchers("/api/email/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리 -->permitAll
 
         );

--- a/src/main/java/com/example/petback/emailauthentication/controller/EmailController.java
+++ b/src/main/java/com/example/petback/emailauthentication/controller/EmailController.java
@@ -1,0 +1,41 @@
+package com.example.petback.emailauthentication.controller;
+
+import com.example.petback.common.advice.ApiResponseDto;
+import com.example.petback.emailauthentication.dto.EmailVerificationRequestDto;
+import com.example.petback.emailauthentication.service.EmailServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+public class EmailController {
+
+    private final EmailServiceImpl emailService;
+
+    // 인증 코드를 email로 보내기
+    @PostMapping("/send-verification")
+    public ResponseEntity<ApiResponseDto> sendEmail(@RequestParam("email") String emails) throws Exception {
+        emailService.sendEmail(emails);
+        return ResponseEntity.ok().body(new ApiResponseDto("이메일 인증 코드 전송 완료", HttpStatus.OK.value()));
+    }
+
+    // 받은 인증 코드를 입력하고 검증하기
+    @PostMapping("/email-check")
+    public ResponseEntity<ApiResponseDto> checkEmail(@RequestBody EmailVerificationRequestDto emailVerificationRequestDto) throws Exception {
+        //email  인증코드 확인
+
+        String enterEmail = emailVerificationRequestDto.getEmail();
+        String enterVerificationCode = emailVerificationRequestDto.getVerificationCode();
+
+        boolean auth = emailService.verificationCodeCheck(enterEmail, enterVerificationCode);
+        if (auth) {
+            return ResponseEntity.ok().body(new ApiResponseDto("이메일 인증 성공", HttpStatus.OK.value()));
+        }
+        return ResponseEntity.badRequest().body(new ApiResponseDto("이메일 인증 실패", HttpStatus.BAD_REQUEST.value()));
+
+    }
+}
+

--- a/src/main/java/com/example/petback/emailauthentication/dto/EmailVerificationRequestDto.java
+++ b/src/main/java/com/example/petback/emailauthentication/dto/EmailVerificationRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.petback.emailauthentication.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailVerificationRequestDto {
+    private String email;
+    private String verificationCode;
+
+    public EmailVerificationRequestDto(String email, String verificationCode) {
+        this.email = email;
+        this.verificationCode=verificationCode;
+    }
+}

--- a/src/main/java/com/example/petback/emailauthentication/service/EmailService.java
+++ b/src/main/java/com/example/petback/emailauthentication/service/EmailService.java
@@ -1,0 +1,8 @@
+package com.example.petback.emailauthentication.service;
+
+public interface EmailService  {
+
+void sendEmail(String email) throws Exception;
+
+boolean verificationCodeCheck(String email, String verificationCode);
+}

--- a/src/main/java/com/example/petback/emailauthentication/service/EmailServiceImpl.java
+++ b/src/main/java/com/example/petback/emailauthentication/service/EmailServiceImpl.java
@@ -15,15 +15,19 @@ import java.util.Random;
 public class EmailServiceImpl implements EmailService {
 
     private final JavaMailSender javaMailSender;
-    private final String verificationCode = makeRandomCode();
-
     private final MailAuthInfoService mailAuthInfoService;
 
     //이메일 전송 메서드
     @Override
     public void sendEmail(String email) throws Exception {
+        // 새로운 코드를 생성
+        String verificationCode = makeRandomCode();
+        // 이메일에 새로운 코드를 포함한 MimeMessage 생성
+        MimeMessage message = joinEmail(email, verificationCode);
+        // 이메일 인증 정보를 저장
+        mailAuthInfoService.setEmailVerificationCode(email, verificationCode);
 
-        MimeMessage message = joinEmail(email);
+
         if (mailAuthInfoService.existData(email)) {
             mailAuthInfoService.deleteData(email);
         }
@@ -33,7 +37,7 @@ public class EmailServiceImpl implements EmailService {
             e.printStackTrace();
             throw new IllegalArgumentException();
         }
-        mailAuthInfoService.setDateExpire(email, verificationCode, 60*5L);
+        mailAuthInfoService.setEmailVerificationCode(email, verificationCode);
     }
 
     // 인증 코드 검증
@@ -41,16 +45,16 @@ public class EmailServiceImpl implements EmailService {
     @Override
     public boolean verificationCodeCheck(String email, String verificationCode) {
         String codeFindByEmail = mailAuthInfoService.getData(email);
-        if(codeFindByEmail == null) {
+        if (codeFindByEmail == null) {
             return false;
         }
-        mailAuthInfoService.save("success",email,60*50L);
+        mailAuthInfoService.save("success", email);
         return mailAuthInfoService.getData(email).equals(verificationCode);
     }
 
 
     // 이메일 보낼 양식
-    public MimeMessage joinEmail(String email) throws Exception {
+    public MimeMessage joinEmail(String email, String verificationCode) throws Exception {
         MimeMessage message = javaMailSender.createMimeMessage();
 
         message.addRecipients(Message.RecipientType.TO, email); //보내는 대상
@@ -73,7 +77,7 @@ public class EmailServiceImpl implements EmailService {
 
     //랜덤코드 생성
     private String makeRandomCode() {
-        StringBuffer key = new StringBuffer();
+        StringBuilder key = new StringBuilder();
         Random random = new Random();
         for (int i = 0; i < 6; i++) { // 6 자리 인증번호, 알파벳 섞이지 않게 한 개씩
             int index = random.nextInt(10); // 0~9까지 랜덤

--- a/src/main/java/com/example/petback/emailauthentication/service/EmailServiceImpl.java
+++ b/src/main/java/com/example/petback/emailauthentication/service/EmailServiceImpl.java
@@ -1,0 +1,84 @@
+package com.example.petback.emailauthentication.service;
+
+import jakarta.mail.Message;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final String verificationCode = makeRandomCode();
+
+    private final MailAuthInfoService mailAuthInfoService;
+
+    //이메일 전송 메서드
+    @Override
+    public void sendEmail(String email) throws Exception {
+
+        MimeMessage message = joinEmail(email);
+        if (mailAuthInfoService.existData(email)) {
+            mailAuthInfoService.deleteData(email);
+        }
+        try {
+            javaMailSender.send(message);
+        } catch (MailException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+        mailAuthInfoService.setDateExpire(email, verificationCode, 60*5L);
+    }
+
+    // 인증 코드 검증
+
+    @Override
+    public boolean verificationCodeCheck(String email, String verificationCode) {
+        String codeFindByEmail = mailAuthInfoService.getData(email);
+        if(codeFindByEmail == null) {
+            return false;
+        }
+        mailAuthInfoService.save("success",email,60*50L);
+        return mailAuthInfoService.getData(email).equals(verificationCode);
+    }
+
+
+    // 이메일 보낼 양식
+    public MimeMessage joinEmail(String email) throws Exception {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(Message.RecipientType.TO, email); //보내는 대상
+        message.setSubject("Pet병 회원 복구 메일 입니다."); //이메일 제목
+
+        String mailMsg = "";
+        mailMsg += "<div>";
+        mailMsg += "Pet병 회원 복구 이메일 인증 코드입니다";
+        mailMsg += "<br>";
+        mailMsg += "CODE : <strong>";
+        mailMsg += verificationCode;
+        mailMsg += "</strong></div>";
+
+        message.setText(mailMsg, "utf-8", "html");
+        message.setFrom(new InternetAddress("muvnelika@gamil.com", "Pet병 Admin"));
+        return message;
+
+
+    }
+
+    //랜덤코드 생성
+    private String makeRandomCode() {
+        StringBuffer key = new StringBuffer();
+        Random random = new Random();
+        for (int i = 0; i < 6; i++) { // 6 자리 인증번호, 알파벳 섞이지 않게 한 개씩
+            int index = random.nextInt(10); // 0~9까지 랜덤
+            key.append(index);
+        }
+        return key.toString();
+    }
+}

--- a/src/main/java/com/example/petback/emailauthentication/service/MailAuthInfoService.java
+++ b/src/main/java/com/example/petback/emailauthentication/service/MailAuthInfoService.java
@@ -1,0 +1,55 @@
+package com.example.petback.emailauthentication.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class MailAuthInfoService {
+    // javamail 인증 정보 저장
+    private StringRedisTemplate redisTemplate;
+
+    public String getData(String key) { // key를 통해 value 를 얻기
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    // 이메일 인증 코드 전송
+    public void setDateExpire(String key, String value, long duration) {
+        //duration 동안 key - value를 저장
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+
+        //인증 코드 값을 value에 저장
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        //데이터 삭제
+        redisTemplate.delete(key);
+    }
+
+    public void save(String key, String value, long duration) {
+        //duration 동안 (key, value)저장
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+
+        //인증 코드 값을 value에 저장
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    // redis 에서 getEmail을 꺼내서 사용
+    public String getEmail(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+}

--- a/src/main/java/com/example/petback/emailauthentication/service/MailAuthInfoService.java
+++ b/src/main/java/com/example/petback/emailauthentication/service/MailAuthInfoService.java
@@ -10,10 +10,11 @@ import java.time.Duration;
 @Service
 @RequiredArgsConstructor
 public class MailAuthInfoService {
-    // javamail 인증 정보 저장
-    private StringRedisTemplate redisTemplate;
+    // redis에 javamail 인증 정보 저장
+    private final StringRedisTemplate redisTemplate;
+    private final Duration DEFAULT_EXPIRE_DURATION = Duration.ofSeconds(60);
 
-    public String getData(String key) { // key를 통해 value 를 얻기
+    public String getData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         return valueOperations.get(key);
     }
@@ -22,34 +23,25 @@ public class MailAuthInfoService {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    // 이메일 인증 코드 전송
-    public void setDateExpire(String key, String value, long duration) {
-        //duration 동안 key - value를 저장
+    public void save(String key, String value) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        Duration expireDuration = Duration.ofSeconds(duration);
-
-        //인증 코드 값을 value에 저장
-        valueOperations.set(key, value, expireDuration);
+        valueOperations.set(key, value, DEFAULT_EXPIRE_DURATION);
     }
 
     public void deleteData(String key) {
-        //데이터 삭제
         redisTemplate.delete(key);
     }
 
-    public void save(String key, String value, long duration) {
-        //duration 동안 (key, value)저장
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        Duration expireDuration = Duration.ofSeconds(duration);
-
-        //인증 코드 값을 value에 저장
-        valueOperations.set(key, value, expireDuration);
+    public String getEmailVerificationCode(String email) {
+        return getData(email);
     }
 
-    // redis 에서 getEmail을 꺼내서 사용
-    public String getEmail(String key) {
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        return valueOperations.get(key);
+    public void setEmailVerificationCode(String email, String code) {
+        save(email, code);
+    }
+
+    public void deleteEmailVerificationCode(String email) {
+        deleteData(email);
     }
 
 }

--- a/src/main/java/com/example/petback/user/controller/UserController.java
+++ b/src/main/java/com/example/petback/user/controller/UserController.java
@@ -54,8 +54,6 @@ public class UserController {
         return ResponseEntity.ok().body(responseDto);
     }
 
-
-
     // 회원정보 수정
     @PutMapping("/profile")
     public ResponseEntity<ApiResponseDto> updateProfile(@RequestBody ProfileRequestDto profileRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -63,18 +61,32 @@ public class UserController {
             return ResponseEntity.ok().body(new ApiResponseDto("프로필 수정 성공", HttpStatus.OK.value()));
     }
 
-
     // 회원 탈퇴
     @DeleteMapping("/profile/{id}")
     public ResponseEntity deleteProfile(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
         userService.deleteProfile(userDetails.getUser(), id);
         return ResponseEntity.ok().body("삭제가 완료되었습니다.");
     }
-    //회원 탈퇴후 복구
-//    @PostMapping("profile/{id}/restore")
-//    public ResponseEntity<String> restoreUser(@PathVariable Long id) {
-//        User currentUser = getCurrentUser();
-//        userService.restoreProfile(currentUser, id);
-//        return ResponseEntity.ok("복구되었습니다.");
-//    }
+    //회원 탈퇴후 복구 -> 입력받은 email을 기준으로 userId 파악
+    @PostMapping("/profile/restore")
+    public ResponseEntity<String> restoreUserData(@RequestParam String email) {
+
+        if (email == null || email.isEmpty()) {
+            return ResponseEntity.badRequest().body("이메일 주소를 입력하세요.");
+        }
+//        email = email.replace("\"", "");
+        Long userId = userService.getUserIdByEmail(email);
+
+        if (userId == null) {
+            return ResponseEntity.badRequest().body("해당 이메일로 등록된 사용자가 없습니다.");
+        }
+
+        try {
+            userService.restoreProfile(userId);
+            return ResponseEntity.ok().body("데이터 복구 완료");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/com/example/petback/user/controller/UserController.java
+++ b/src/main/java/com/example/petback/user/controller/UserController.java
@@ -70,4 +70,11 @@ public class UserController {
         userService.deleteProfile(userDetails.getUser(), id);
         return ResponseEntity.ok().body("삭제가 완료되었습니다.");
     }
+    //회원 탈퇴후 복구
+//    @PostMapping("profile/{id}/restore")
+//    public ResponseEntity<String> restoreUser(@PathVariable Long id) {
+//        User currentUser = getCurrentUser();
+//        userService.restoreProfile(currentUser, id);
+//        return ResponseEntity.ok("복구되었습니다.");
+//    }
 }

--- a/src/main/java/com/example/petback/user/entity/User.java
+++ b/src/main/java/com/example/petback/user/entity/User.java
@@ -28,7 +28,7 @@ import java.util.List;
 @Builder
 @Table(name = "users")
 @EqualsAndHashCode(of = "id")
-//@Where(clause = "is_deleted = false") ??????????????????????????
+@Where(clause = "is_deleted = false")
 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 public class User {
     @Id

--- a/src/main/java/com/example/petback/user/entity/User.java
+++ b/src/main/java/com/example/petback/user/entity/User.java
@@ -28,7 +28,7 @@ import java.util.List;
 @Builder
 @Table(name = "users")
 @EqualsAndHashCode(of = "id")
-@Where(clause = "is_deleted = false")
+//@Where(clause = "is_deleted = false") ??????????????????????????
 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 public class User {
     @Id

--- a/src/main/java/com/example/petback/user/entity/User.java
+++ b/src/main/java/com/example/petback/user/entity/User.java
@@ -47,6 +47,11 @@ public class User {
     @Builder.Default
     private boolean isDeleted = Boolean.FALSE;
 
+    //삭제 데이터 복구용 메싸드
+    public void restore() {
+        this.isDeleted = false;
+    }
+
     @Column
     private String imageUrl;
 

--- a/src/main/java/com/example/petback/user/repository/UserRepository.java
+++ b/src/main/java/com/example/petback/user/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.example.petback.user.repository;
 
 import com.example.petback.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -13,4 +16,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 
     void deleteByUsername(String testUser);
+
+    User findByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.isDeleted = true")
+    User findByEmailIgnoringSoftDelete(@Param("email") String email);
+
+    @Modifying
+    @Query("UPDATE User u SET u.isDeleted = false WHERE u.email = :email")
+    void restoreByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/example/petback/user/service/UserService.java
+++ b/src/main/java/com/example/petback/user/service/UserService.java
@@ -26,9 +26,11 @@ public interface UserService {
     // 회원 탈퇴
     void deleteProfile(User user, Long id);
     // 회원 탈퇴 복구
-    void restoreProfile(User user, Long id);
+    void restoreProfile(Long id);
 
     User findUser(Long id);
 
     Map<String, String> refreshToken(String refreshToken);
+
+    Long getUserIdByEmail(String email);
 }

--- a/src/main/java/com/example/petback/user/service/UserService.java
+++ b/src/main/java/com/example/petback/user/service/UserService.java
@@ -25,6 +25,8 @@ public interface UserService {
 
     // 회원 탈퇴
     void deleteProfile(User user, Long id);
+    // 회원 탈퇴 복구
+    void restoreProfile(User user, Long id);
 
     User findUser(Long id);
 

--- a/src/main/java/com/example/petback/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/petback/user/service/UserServiceImpl.java
@@ -154,7 +154,7 @@ public class UserServiceImpl implements UserService {
     //softDelete된 데이터도 검색
     @Override
     public Long getUserIdByEmail(String email) {
-        User user = userRepository.findByEmailIgnoringSoftDelete(email);
+        User user = userRepository.findByEmail(email);
         if (user != null) {
             return user.getId();
         }

--- a/src/main/java/com/example/petback/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/petback/user/service/UserServiceImpl.java
@@ -90,46 +90,35 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("탈퇴 권한이 없습니다.");
         }
 
-
         // 채팅방, > 탈퇴시 안지워짐
-        List<Comment> comments = userToDelete.getComments();
-        for (Comment comment : comments) {
-            comment.setDeleted(true);
-        }
+        userToDelete.getComments().forEach(comment -> comment.setDeleted(true));
+        userToDelete.getFeeds().forEach(feed -> feed.setDeleted(true));
+        userToDelete.getFeedLikes().forEach(feedLike -> feedLike.setDeleted(true));
+        userToDelete.getChatMessages().forEach(chatMessage -> chatMessage.setDeleted(true));
+        userToDelete.getHospitals().forEach(Hospital::setDeleted);
+        userToDelete.getReservations().forEach(reservation -> reservation.setDeleted(true));
+        userToDelete.getReviews().forEach(review -> review.setDeleted(true));
 
-        List<Feed> feeds = userToDelete.getFeeds();
-        for (Feed feed : feeds) {
-            feed.setDeleted(true);
-        }
-
-        List<FeedLike> feedLikes = userToDelete.getFeedLikes();
-        for (FeedLike feedLike : feedLikes) {
-            feedLike.setDeleted(true);
-        }
-
-        List<ChatMessage> chatMessages = userToDelete.getChatMessages();
-        for (ChatMessage chatMessage : chatMessages) {
-            chatMessage.setDeleted(true);
-        }
-
-        List<Hospital> hospitals = userToDelete.getHospitals();
-        for (Hospital hospital : hospitals) {
-            hospital.setDeleted();
-        }
-
-        List<Reservation> reservations = userToDelete.getReservations();
-        for (Reservation reservation : reservations) {
-            reservation.setDeleted(true);
-        }
-        List<Review> reviews = userToDelete.getReviews();
-        for (Review review : reviews) {
-            review.setDeleted(true);
-        }
-
+        // UserRepository 를 통해 변경 사항을 저장
         userRepository.flush();
+
+        // User 엔티티의 삭제 상태 설정 및 저장
         userToDelete.setDeleted(true);
         userRepository.save(userToDelete);
     }
+
+    //회원탈퇴 시 삭제된 데이터 복구
+    @Override
+    @Transactional
+    public void restoreProfile(User user, Long id) {
+        User userToRestore = userRepository.findById(id).orElse(null);
+        if (userToRestore != null) {
+            // user 엔티티 복구
+            userToRestore.restore();
+            userRepository.save(userToRestore);
+        }
+    }
+
 
     @Override
     public User findUser(Long id) {
@@ -149,4 +138,6 @@ public class UserServiceImpl implements UserService {
         tokens.put("refreshToken", refreshToken); // 기존 refreshToken 유효하므로 그대로 반환
         return tokens;
     }
+
+
 }


### PR DESCRIPTION
users DB에서 softDelete / is_deleted = true가 된 탈퇴 회원의 정보를 다시 되살립니다.

로직을 통과하면 SoftDelete /is_deleted = false로 변경되며 다시 로그인이 가능합니다.

현재 유저 로그인 같은 회원 관련 기능만 되살아나고, 연관관계를 확장하면 softDelete 된 다른 데이터들도 복구가 가능 할것으로 보임