### PR TITLE
[Fix] 알림기능 스케쥴러관련 로드밸런서 적용시 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ dependencies {
     implementation 'top.jfunc.json:json-gson:1.8.3'
     implementation 'junit:junit:4.13.2'
     implementation 'junit:junit:4.13.2'
-
+    // ShedLock
+    implementation "net.javacrumbs.shedlock:shedlock-spring:4.44.0"
+    implementation "net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.44.0"
     // JWT
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/example/petback/common/config/SchedulerConfig.java
+++ b/src/main/java/com/example/petback/common/config/SchedulerConfig.java
@@ -1,0 +1,22 @@
+package com.example.petback.common.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(dataSource);
+    }
+}

--- a/src/main/java/com/example/petback/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/petback/notification/service/NotificationServiceImpl.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
 
 @Slf4j
 @Service
@@ -66,6 +68,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Transactional
     @Scheduled(fixedRate = 60000 * 10)
+    @SchedulerLock(name = "checkReservationLock", lockAtMostFor = "10m", lockAtLeastFor = "10m")
     public void checkReservation() {
         log.info("스케쥴러 실행");
         LocalDateTime later = LocalDateTime.now().plusMinutes(6);

--- a/src/main/java/com/example/petback/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/petback/notification/service/NotificationServiceImpl.java
@@ -67,7 +67,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Transactional
-    @Scheduled(fixedRate = 60000 * 10)
+    @Scheduled(fixedRate = 1000 * 60)
     @SchedulerLock(name = "checkReservationLock", lockAtMostFor = "10m", lockAtLeastFor = "10m")
     public void checkReservation() {
         log.info("스케쥴러 실행");

--- a/src/main/java/com/example/petback/reservationslot/service/ReservationSlotScheduler.java
+++ b/src/main/java/com/example/petback/reservationslot/service/ReservationSlotScheduler.java
@@ -6,6 +6,7 @@ import com.example.petback.hospital.repository.HospitalRepository;
 import com.example.petback.reservationslot.entity.ReservationSlot;
 import com.example.petback.reservationslot.repository.ReservationSlotRepository;
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class ReservationSlotScheduler {
 //     매일 오전 4시에 실행될 메서드
     @Transactional
     @Scheduled(cron = "0 0 4 * * ?")
+    @SchedulerLock(name = "addReservationSlotsLock", lockAtMostFor = "10m", lockAtLeastFor = "5m")
     public void addReservationSlots() {
         LocalDate twoMonthsLater = LocalDate.now().plusMonths(2);
         OperatingDay dayOfWeek = OperatingDay.valueOf(twoMonthsLater.getDayOfWeek().name());


### PR DESCRIPTION
- 2개 이상의 서버에서 중복 수행을 방지하도록 Lock 을 걸게 하는 라이브러리로 shedlock을 사용.
- db 에 shedlock 테이블을 생성 후, 스케줄 메소드에 어노테이션을 추가하여 락을 걸어주는 시간을 설정하여 해당 시간동안은 스케줄러가 수행되지 못하도록 함